### PR TITLE
move require for commands into the bin so the gem can be used as a library

### DIFF
--- a/bin/mkgitignore
+++ b/bin/mkgitignore
@@ -2,6 +2,11 @@
 
 require 'commander/import'
 require 'mkgitignore'
+require 'mkgitignore/commands/list'
+require 'mkgitignore/commands/search'
+require 'mkgitignore/commands/build'
+require 'mkgitignore/commands/listbuild'
+require 'mkgitignore/commands/append'
 
 # Thanks @mattt
 HighLine.track_eof = false # Fix for built-in Ruby

--- a/lib/mkgitignore.rb
+++ b/lib/mkgitignore.rb
@@ -166,10 +166,3 @@ module Mkgitignore
   end
 end
 
-
-require 'mkgitignore/commands/list'
-require 'mkgitignore/commands/search'
-require 'mkgitignore/commands/build'
-require 'mkgitignore/commands/listbuild'
-require 'mkgitignore/commands/append'
-


### PR DESCRIPTION
Hey,
I've moved the `require` statements for the `command` files into the executable in the bin folder so the gem can be used as a library without breaking because of the `commander` requirements.  
